### PR TITLE
Export SG to ssh from bastion to instances

### DIFF
--- a/aws/network/bastion/main.tf
+++ b/aws/network/bastion/main.tf
@@ -90,3 +90,7 @@ resource "aws_instance" "bastion" {
 output "instance_id" {
   value = "${aws_instance.bastion.id}"
 }
+
+output "sg_from_bastion" {
+  value = "${aws_security_group.ssh_from_bastion.id}"
+}


### PR DESCRIPTION
This export is needed to pick up the generated SG-ID to add them to all servers the bastion host will connect to
